### PR TITLE
Daemonize should not close stdout/stderr

### DIFF
--- a/actkbd.c
+++ b/actkbd.c
@@ -295,7 +295,7 @@ int main(int argc, char **argv) {
 	showkey = 0;
 
     if (detach) {
-	switch (daemon(0, 0))
+	switch (daemon(0, 1))
 	{
 	    case 0:
     		break;


### PR DESCRIPTION
Currently, when actkbd is daemonized, the [noclose argument](http://man7.org/linux/man-pages/man3/daemon.3.html#DESCRIPTION) is given as zero in order to prevent logging to stdout and stderr in the style of traditional non-interactive daemons.

For many people using systemd, a service unit might contain something like this:

```
[Service]
Type=forking
ExecStart=/usr/bin/actkbd -c /.../actkbd.conf -d /dev/input/event2 --daemon
```
where logs to stdout/stderr should normally show up via `journalctl -u actkbd`.

However, since logging is turned off by the `--daemon` flag, this causes a huge amount of confusion when the environment from which `actkbd` is being executed lacks the correct permissions / environment variables for the commands you are running.

Additional motivating points:

* A possible alternative solution is to *not* use `--daemon` and instead create a systemd unit of `Type=simple`. However, this seems to have its [own downsides](https://www.lucas-nussbaum.net/blog/?p=877).
* Using syslog is an alternative option, but it is a rather complicated solution to a simple problem. E.g. on my system adding `-l` segfaults, leading the average jane/joe down the peculiar unixy rabbit hole that is "What is this thing X and why does it break my system?".
* It is already super simple and clear how to turn off logging explicitly (via `--quiet`). *Keeping* the logs should be equally simple and, I'd argue, the correct default for most people.